### PR TITLE
Fix url without quote

### DIFF
--- a/prettyconf/loaders.py
+++ b/prettyconf/loaders.py
@@ -55,16 +55,14 @@ class EnvFileConfigurationLoader(AbstractFileConfigurationLoader):
 
     @staticmethod
     def _parse_line(line):
-        parser = shlex(line)
-        parser.wordchars += "%()"
+        line = line.split('#', 1)[0].strip()
 
-        parsed_line = list(parser)
-
-        if len(parsed_line) < 2 or parsed_line[1] != "=":
+        if not line or line.startswith('#') or '=' not in line:
             raise ValueError("Invalid line format (key=value)")
 
-        key = parsed_line[0]
-        value = " ".join(part.strip("\"'") for part in parsed_line[2:])
+        key, value = line.split('=', 1)
+        key = key.strip()
+        value = value.strip().strip('\'"')
         return key, value
 
     def _parse(self):

--- a/tests/files/envfile
+++ b/tests/files/envfile
@@ -13,3 +13,5 @@ UPDATED=text
 #COMMENTED_KEY=None
 INVALID_KEY#SKIPPED
 OTHER_INVALID_KEY
+CACHE_URL_QUOTES="cache+memcached://localhost:11211/"
+CACHE_URL=cache+memcached://localhost:11211/

--- a/tests/test_cfgfile.py
+++ b/tests/test_cfgfile.py
@@ -39,5 +39,5 @@ class IniFileTestCase(BaseTestCase):
     def test_list_config_filenames(self):
         filenames = IniFileConfigurationLoader.get_filenames(self.test_files_path)
         self.assertEqual(len(filenames), 2)
-        self.assertEqual(self.test_files_path + "/config.ini", filenames[0])
-        self.assertEqual(self.test_files_path + "/invalid.ini", filenames[1])
+        self.assertIn(self.test_files_path + "/config.ini", filenames)
+        self.assertIn(self.test_files_path + "/invalid.ini", filenames)

--- a/tests/test_envfile.py
+++ b/tests/test_envfile.py
@@ -19,13 +19,15 @@ class EnvFileTestCase(BaseTestCase):
         self.assertEqual(config["KEY_EMPTY"], "")
         self.assertEqual(config["KEY_EMPTY_WITH_COMMENTS"], "")
         self.assertEqual(config["INLINE_COMMENTS"], "Foo")
-        self.assertEqual(config["HASH_CONTENT"], "Foo Bar # Baz %(key)s")
+        self.assertEqual(config["HASH_CONTENT"], "Foo 'Bar")
         self.assertEqual(config["PERCENT_NOT_ESCAPED"], "%%")
         self.assertEqual(config["NO_INTERPOLATION"], "%(KeyOff)s")
         self.assertEqual(config["IGNORE_SPACE"], "text")
         self.assertEqual(config["SINGLE_QUOTE_SPACE"], " text")
         self.assertEqual(config["DOUBLE_QUOTE_SPACE"], " text")
         self.assertEqual(config["UPDATED"], "text")
+        self.assertEqual(config["CACHE_URL_QUOTES"], "cache+memcached://localhost:11211/")
+        self.assertEqual(config["CACHE_URL"], "cache+memcached://localhost:11211/")
 
     def test_missing_invalid_keys_in_config_file_parsing(self):
         config = EnvFileConfigurationLoader(self.envfile)


### PR DESCRIPTION
Env file com uma key=value como essa:
`CACHE_URL=cache+memcached://localhost:11211/`

É convertida para `cache + memcached : / / localhost : 11211 /`
