### PR TITLE
Add root path limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.4
   - pypy
 install:
-  - pip install coveralls
+  - pip install coveralls testfixtures
 script:
   nosetests --with-coverage --cover-package=prettyconf
 after_success:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+0.4.0
+=====
+  
+  - Add ``root_path`` to stop looking indefinitely for configuration files until the OS root path
+  - Add advanced usage docs
+  - Include a simple (but working) tox configuration for py27 + py34 to the project
+
+
 0.3.3
 =====
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -80,6 +80,82 @@ Useful third-parties casts
 * `django-cache-url`_ - Parses URLs like ``memcached://server:port/prefix``
   into Django ``CACHES`` configuration format.
 
+
+Advanced usage
+~~~~~~~~~~~~~~
+You can always create your own ``Configuration`` instance and change it's default behaviour.
+
+.. code-block:: python
+
+    from prettyconf.configuration import Configuration
+    config = Configuration()
+
+Set the starting path
++++++++++++++++++++++
+By default the library will use the directory of the file where ``config()`` was called 
+as the starting directory to look for configuration files. Consider the following file 
+structure:
+
+.. code-block:: shell
+
+    project/
+      settings.ini
+      app/
+        settings.py
+
+When calling ``config()`` from ``project/app/settings.py`` the library will start looking
+for configuration files at ``project/app``
+
+You can change that behaviour, by setting a different ``starting_path`` when instantiating
+your ``Configuration``:
+
+.. code-block:: python
+
+    # Code example in project/app/settings.py
+    import os
+
+    from prettyconf.configuration import Configuration
+
+    project_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
+    config = Configuration(project_path)
+
+The example above will start looking for files at ``project/`` instead of ``project/app``.
+
+Set a different root path
++++++++++++++++++++++++++
+By default, the library will try to look for configuration files until it finds valid 
+configuration files **or** it reaches ``Configuration.root_path``.
+
+Consider the following file structure:
+
+.. code-block:: shell
+    
+    /projects/
+      any_settings.ini
+      project/
+        app/
+          settings.py
+
+The default root path is set to the user home directory (e.g. ``$HOME`` or 
+``/home/yourusername``). You can change this behaviour by setting any parent directory 
+of the ``starting_path`` as the ``root_path`` when instantiating ``Configuration``:
+
+.. code-block:: python
+
+    # Code example in project/app/settings.py
+    import os
+
+    from prettyconf.configuration import Configuration
+
+    app_path = os.path.dirname(__file__)
+    project_path = os.path.realpath(os.path.join(app_path), '..'))
+
+    config = Configuration(root_path=project_path)
+
+The example above will start looking for files at ``project/app/`` and will stop looking
+for configuration files at ``project/``, actually never looking at ``any_settings.ini``
+and no configuration being loaded at all.
+
 .. _dj-database-url: https://github.com/kennethreitz/dj-database-url
 .. _django-cache-url: https://github.com/ghickman/django-cache-url
 

--- a/prettyconf/configuration.py
+++ b/prettyconf/configuration.py
@@ -15,12 +15,28 @@ MAGIC_FRAME_DEPTH = 2
 class ConfigurationDiscovery(object):
     default_filetypes = (EnvFileConfigurationLoader, IniFileConfigurationLoader)
 
-    def __init__(self, starting_path, filetypes=None):
+    def __init__(self, starting_path, filetypes=None, root_path=None):
+        """
+        Setup the configuration file discovery.
+
+        :param starting_path: The path to begin looking for configuration files
+        :param filetypes: tuple with configuration loaders. Defaults to
+                          ``(EnvFileConfigurationLoader, IniFileConfigurationLoader)``
+        :param root_path: Configuration lookup will stop at the given path. Defaults to
+                          the current user directory
+        """
         self.starting_path = os.path.realpath(os.path.abspath(starting_path))
         if filetypes is None:
             filetypes = self.default_filetypes
+        if root_path is None:
+            root_path = os.path.expanduser('~')
+
+        self.root_path = os.path.realpath(root_path)
         self.filetypes = filetypes
         self._config_files = None
+
+        if self.root_path not in self.starting_path:
+            raise InvalidPath('Invalid root path given')
 
     def _scan_path(self, path):
         config_files = []
@@ -44,7 +60,7 @@ class ConfigurationDiscovery(object):
 
             self._config_files += self._scan_path(path)
 
-            if self._config_files or path == os.path.sep:
+            if self._config_files or path == self.root_path or path == os.path.sep:
                 break
 
             path = os.path.dirname(path)

--- a/prettyconf/configuration.py
+++ b/prettyconf/configuration.py
@@ -79,11 +79,12 @@ class Configuration(object):
     list = List()
     option = Option
 
-    def __init__(self, configs=None, starting_path=None):
+    def __init__(self, configs=None, starting_path=None, root_path=None):
         if configs is None:
             configs = [EnvVarConfigurationLoader()]
         self.configurations = configs
         self.starting_path = starting_path
+        self.root_path = root_path
 
         if starting_path:
             self._init_configs()
@@ -97,7 +98,7 @@ class Configuration(object):
         return path
 
     def _init_configs(self):
-        discovery = ConfigurationDiscovery(self.starting_path)
+        discovery = ConfigurationDiscovery(self.starting_path, root_path=self.root_path)
         self.configurations.extend(discovery.config_files)
 
     def __call__(self, item, cast=lambda v: v, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27, py34
+
+[testenv]
+commands = python setup.py test
+deps =
+    nose
+

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ envlist = py27, py34
 commands = python setup.py test
 deps =
     nose
-
+    testfixtures


### PR DESCRIPTION
I'm adding a "root path" concept to prettyconf. Instead of looking for configuration files until we reach the OS root path (e.g.: `/` on Unix systems) we now stop at the user's directory by default (e.g: `/home/yourusername`) **and** give the user of the library ability to change this behaviour (see `docs/usage.rst` at advanced usage for more information).