### PR TITLE
Handle MissingSectionHeaderError and ignore them when loading Ini Files

### DIFF
--- a/prettyconf/configuration.py
+++ b/prettyconf/configuration.py
@@ -37,7 +37,6 @@ class ConfigurationDiscovery(object):
         self.filetypes = filetypes
         self._config_files = None
 
-
     def _scan_path(self, path):
         config_files = []
 

--- a/prettyconf/loaders.py
+++ b/prettyconf/loaders.py
@@ -5,9 +5,9 @@ import os
 from glob import glob
 
 try:
-    from ConfigParser import SafeConfigParser as ConfigParser, NoOptionError
+    from ConfigParser import SafeConfigParser as ConfigParser, NoOptionError, MissingSectionHeaderError
 except ImportError:
-    from configparser import ConfigParser, NoOptionError
+    from configparser import ConfigParser, NoOptionError, MissingSectionHeaderError
 
 from .exceptions import InvalidConfigurationFile
 
@@ -160,7 +160,7 @@ class IniFileConfigurationLoader(AbstractFileConfigurationLoader):
                     self.parser.readfp(inifile)
                 else:
                     self.parser.read_file(inifile)
-            except UnicodeDecodeError:
+            except (UnicodeDecodeError, MissingSectionHeaderError):
                 raise InvalidConfigurationFile()
 
         if not self.parser.has_section(self.section):

--- a/tests/test_filediscover.py
+++ b/tests/test_filediscover.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import unicode_literals
 
 import os
 
@@ -7,6 +8,7 @@ from testfixtures import TempDirectory
 from .base import BaseTestCase
 from prettyconf.configuration import ConfigurationDiscovery
 from prettyconf.exceptions import InvalidPath
+from prettyconf.loaders import IniFileConfigurationLoader
 
 
 # noinspection PyStatementEffect
@@ -100,3 +102,15 @@ class ConfigFilesDiscoveryTestCase(BaseTestCase):
 
         discovery = ConfigurationDiscovery(start_path, root_path=root_dir)
         self.assertEqual(discovery.config_files, [])
+
+    def test_inifile_discovery_should_ignore_invalid_files_without_raising_exception(self):
+        root_dir = TempDirectory()
+        self.tmpdirs.append(root_dir)
+
+        cfg_file = root_dir.write(('some', 'strange', 'config.cfg'), '&ˆ%$#$%ˆ&*()(*&ˆ'.encode('utf8'))
+        root_dir.write(('some', 'config.ini'), '$#%ˆ&*((*&ˆ%'.encode('utf8'))
+
+        discovery = ConfigurationDiscovery(
+            os.path.realpath(os.path.dirname(cfg_file)), filetypes=(IniFileConfigurationLoader, ))
+
+        self.assertEqual(discovery.config_files,  [])

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from testfixtures import TempDirectory
+
+from prettyconf.exceptions import InvalidConfigurationFile
+
+from .base import BaseTestCase
+
+
+class IniFileConfigurationLoaderTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(IniFileConfigurationLoaderTestCase, self).setUp()
+        self.tmp_dir = TempDirectory()
+
+    def tearDown(self):
+        super(IniFileConfigurationLoaderTestCase, self).tearDown()
+        self.tmp_dir.cleanup_all()
+
+    def test_skip_invalid_ini_file(self):
+        from prettyconf.loaders import IniFileConfigurationLoader
+
+        test_file = self.tmp_dir.write('some/strange/config.cfg', '*&ˆ%$#$%ˆ&*('.encode('utf8'))
+        with self.assertRaises(InvalidConfigurationFile):
+            IniFileConfigurationLoader(test_file)


### PR DESCRIPTION
Invalid INI files were not being ignored when the settings header was missing, raising
a `MissingSectionHeaderError`. Now an `InvalidConfigurationFile` will be raised instead
and the same behaviour of ignoring those files will work