### PR TITLE
Add official support to Python 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - os: linux
       python: 3.4
     - os: linux
+      python: 3.5
+    - os: linux
       python: pypy
     - os: osx
       language: generic
@@ -20,6 +22,12 @@ matrix:
       language: generic
       env:
       - PYTHON_VERSION=3.4.3
+      - PYENV_ROOT=~/.pyenv
+      - PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+    - os: osx
+      language: generic
+      env:
+      - PYTHON_VERSION=3.5.0
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
     - os: osx

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py27, py34, py35
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
Both tox and travis settings were updated, so we are ready to track py3.5
regressions.