### PR TITLE
Add AwsParameterStore loader

### DIFF
--- a/docs/source/loaders.rst
+++ b/docs/source/loaders.rst
@@ -197,3 +197,28 @@ The ``root_path`` must be a parent directory of ``starting_path``:
 
     # /baz is not parent of /foo/bar, so this raises an InvalidPath exception here
     rs = RecursiveSearch(starting_path="/foo/bar", root_path="/baz")
+
+
+AwsParameterStore
++++++++++++++++++
+
+.. autoclass:: prettyconf.loaders.AwsParameterStore
+
+The ``AwsParameterStore`` loader gets configuration from the AWS Parameter Store,
+part of AWS Systems Manager. The loader will be skipped if the parameter store is 
+unreachable (connectivity, unavailability, access permissions).
+The loader respects parameter hierarchies, performing non-recursive discoveries.
+The loader accepts AWS access secrets and region when instantiated, otherwise, it 
+will use system-wide defaults (if available).
+The AWS parameter store supports three parameter types: ``String``, ``StringList`` 
+and ``SecureString``. All types are read as strings, however, decryption of 
+``SecureStrings`` is not handled by the loader.
+
+.. code-block:: python
+
+    from prettyconf import config
+    from prettyconf.loaders import AwsParameterStore
+
+
+    config.loaders = [AwsParameterStore(path='/api')]
+    config('debug')  # will look for a parameter named "/api/debug" in the store

--- a/prettyconf/loaders.py
+++ b/prettyconf/loaders.py
@@ -2,6 +2,9 @@ import os
 from configparser import ConfigParser, MissingSectionHeaderError, NoOptionError
 from glob import glob
 
+import boto3
+import botocore
+
 from .exceptions import InvalidConfigurationFile, InvalidPath, MissingSettingsSection
 from .parsers import EnvFileParser
 
@@ -301,3 +304,62 @@ class RecursiveSearch(AbstractConfigurationLoader):
                 continue
         else:
             raise KeyError("{!r}".format(item))
+
+
+class AwsParameterStore(AbstractConfigurationLoader):
+    def __init__(self, path="/", aws_access_key_id=None, aws_secret_access_key=None, region_name="us-east-1"):
+        self.path = path
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.region_name = region_name
+        self._fetched = False
+        self._parameters = {}
+
+    def _store_parameters(self, parameters):
+        for parameter in parameters:
+            self._parameters[parameter["Name"].split("/")[-1]] = parameter["Value"]
+
+    def _fetch_parameters(self):
+        if self._fetched:
+            return
+
+        client = boto3.client(
+            service_name="ssm",
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            region_name=self.region_name,
+        )
+
+        response = client.get_parameters_by_path(Path=self.path)
+        next_token = response.get("NextToken")
+        self._store_parameters(response["Parameters"])
+
+        while next_token:
+            response = client.get_parameters_by_path(Path=self.path, NextToken=next_token)
+            next_token = response.get("NextToken")
+            self._store_parameters(response["Parameters"])
+
+        self._fetched = True
+
+    def check(self):
+        try:
+            self._fetch_parameters()
+        except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError):
+            return False
+
+        return super().check()
+
+    def __repr__(self):
+        return "AwsParameterStore(path={} region={})".format(self.path, self.region_name)
+
+    def __contains__(self, item):
+        if not self.check():
+            return False
+
+        return item in self._parameters
+
+    def __getitem__(self, item):
+        if not self.check():
+            raise KeyError("{!r}".format(item))
+
+        return self._parameters[item]

--- a/prettyconf/loaders.py
+++ b/prettyconf/loaders.py
@@ -148,7 +148,7 @@ class Environment(AbstractConfigurationLoader):
         self.var_format = var_format
 
     def __repr__(self):
-        return "Environment(var_format={}>".format(self.var_format)
+        return "Environment(var_format={})".format(self.var_format)
 
     def __contains__(self, item):
         return self.var_format(item) in os.environ

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     author="Osvaldo Santana Neto", author_email="prettyconf@osantana.me",
     license="MIT",
     packages=['prettyconf'],
+    install_requires=['boto3'],
     platforms='any',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/test_parameterstore.py
+++ b/tests/test_parameterstore.py
@@ -1,0 +1,84 @@
+from unittest import mock
+
+import botocore
+
+from prettyconf.loaders import AwsParameterStore
+from .base import BaseTestCase
+
+
+PARAMETER_RESPONSE = {
+    "Parameters": [
+        {
+            "Name": "DEBUG",
+            "Type": "String",
+            "Value": "false",
+        },
+        {
+            "Name": "HOST",
+            "Type": "String",
+            "Value": "host_url",
+        },
+    ],
+}
+
+PARAMETER_RESPONSE_FIRST_PAGE = {
+    "Parameters": [
+        {
+            "Name": "/api/DEBUG",
+            "Type": "String",
+            "Value": "false",
+        },
+    ],
+    "NextToken": "token",
+}
+
+PARAMETER_RESPONSE_LAST_PAGE = {
+    "Parameters": [
+        {
+            "Name": "/api/HOST",
+            "Type": "String",
+            "Value": "host_url",
+        },
+    ],
+}
+
+
+class AwsParameterStoreTestCase(BaseTestCase):
+    @mock.patch("prettyconf.loaders.boto3")
+    def test_basic_config(self, mock_boto):
+        mock_boto.client.return_value.get_parameters_by_path.return_value = PARAMETER_RESPONSE
+        config = AwsParameterStore()
+
+        self.assertIn("HOST", config)
+        self.assertEqual(config["HOST"], "host_url")
+        self.assertTrue(repr(config).startswith("AwsParameterStore(path="))
+
+    @mock.patch("prettyconf.loaders.boto3")
+    def test_basic_config_response_paginated(self, mock_boto):
+        mock_boto.client.return_value.get_parameters_by_path.side_effect = [
+            PARAMETER_RESPONSE_FIRST_PAGE, PARAMETER_RESPONSE_LAST_PAGE,
+        ]
+        config = AwsParameterStore()
+
+        self.assertIn("HOST", config)
+        self.assertIn("DEBUG", config)
+        self.assertEqual(config["HOST"], "host_url")
+        self.assertEqual(config["DEBUG"], "false")
+
+    @mock.patch("prettyconf.loaders.boto3")
+    def test_fail_missing_config(self, mock_boto):
+        mock_boto.client.return_value.get_parameters_by_path.return_value = PARAMETER_RESPONSE
+        config = AwsParameterStore()
+
+        self.assertNotIn("DATABASE_URL", config)
+        with self.assertRaises(KeyError):
+            config["DATABASE_URL"]
+
+    @mock.patch("prettyconf.loaders.boto3")
+    def test_parameter_store_access_fail(self, mock_boto):
+        mock_boto.client.return_value.get_parameters_by_path.side_effect = botocore.exceptions.BotoCoreError
+        config = AwsParameterStore()
+
+        self.assertNotIn("DATABASE_URL", config)
+        with self.assertRaises(KeyError):
+            config["DATABASE_URL"]


### PR DESCRIPTION
The `AwsParameterStore` loader is able to fetch configuration parameters from the [AWS Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).

The loader makes use of parameter hierarchies, allowing, for instance, storage of configuration data in the store for multiple applications. Parameters are loaded using the [GetParametersByPath](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html) service.