### PR TITLE
Make boto3 dependency optional

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,3 +12,9 @@ First you need to install ``prettyconf`` library:
 .. code-block:: sh
 
     pip install prettyconf
+
+The ``AwsParameterStore`` configuration loader depends on the ``boto3`` package.
+If you need to use it, install ``prettyconf`` with the optional feature ``aws``:
+
+.. code-block:: sh
+    pip install prettyconf[aws]

--- a/prettyconf/loaders.py
+++ b/prettyconf/loaders.py
@@ -5,9 +5,8 @@ from glob import glob
 try:
     import boto3
     import botocore
-    _have_boto = True
 except ImportError:
-    _have_boto = False
+    boto3 = None
 
 from .exceptions import InvalidConfigurationFile, InvalidPath, MissingSettingsSection
 from .parsers import EnvFileParser
@@ -312,8 +311,10 @@ class RecursiveSearch(AbstractConfigurationLoader):
 
 class AwsParameterStore(AbstractConfigurationLoader):
     def __init__(self, path="/", aws_access_key_id=None, aws_secret_access_key=None, region_name="us-east-1"):
-        if not _have_boto:
-            raise RuntimeError("'boto3' package is required by AwsParameterStore loader.")
+        if not boto3:
+            raise RuntimeError(
+                'AwsParameterStore requires [aws] feature. Please install it: "pip install prettyconf[aws]"'
+            )
 
         self.path = path
         self.aws_access_key_id = aws_access_key_id

--- a/prettyconf/loaders.py
+++ b/prettyconf/loaders.py
@@ -2,8 +2,12 @@ import os
 from configparser import ConfigParser, MissingSectionHeaderError, NoOptionError
 from glob import glob
 
-import boto3
-import botocore
+try:
+    import boto3
+    import botocore
+    _have_boto = True
+except ImportError:
+    _have_boto = False
 
 from .exceptions import InvalidConfigurationFile, InvalidPath, MissingSettingsSection
 from .parsers import EnvFileParser
@@ -308,6 +312,9 @@ class RecursiveSearch(AbstractConfigurationLoader):
 
 class AwsParameterStore(AbstractConfigurationLoader):
     def __init__(self, path="/", aws_access_key_id=None, aws_secret_access_key=None, region_name="us-east-1"):
+        if not _have_boto:
+            raise RuntimeError("'boto3' package is required by AwsParameterStore loader.")
+
         self.path = path
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+boto3
+coveralls
 pytest
 pytest-cov
 pytest-runner
 Sphinx
 sphinx-rtd-theme
 twine
-coveralls

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     author="Osvaldo Santana Neto", author_email="prettyconf@osantana.me",
     license="MIT",
     packages=['prettyconf'],
-    install_requires=['boto3'],
+    extras_require={'aws': ['boto3']},
     platforms='any',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_parameterstore.py
+++ b/tests/test_parameterstore.py
@@ -46,19 +46,15 @@ PARAMETER_RESPONSE_LAST_PAGE = {
 
 
 @pytest.fixture
-def missing_boto():
-    loaders = sys.modules['prettyconf.loaders']
-
+def boto_not_installed():
     sys.modules['boto3'] = None
-    importlib.reload(loaders)
-
+    importlib.reload(sys.modules['prettyconf.loaders'])
     yield
-
     sys.modules.pop('boto3')
-    importlib.reload(loaders)
+    importlib.reload(sys.modules['prettyconf.loaders'])
 
 
-def test_parameter_store_boto_not_available(missing_boto):
+def test_create_loader_boto_not_installed(boto_not_installed):
     with pytest.raises(RuntimeError):
         AwsParameterStore()
 

--- a/tests/test_parameterstore.py
+++ b/tests/test_parameterstore.py
@@ -1,3 +1,5 @@
+import importlib
+import sys
 from unittest import mock
 
 import pytest
@@ -41,6 +43,24 @@ PARAMETER_RESPONSE_LAST_PAGE = {
         },
     ],
 }
+
+
+@pytest.fixture
+def missing_boto():
+    loaders = sys.modules['prettyconf.loaders']
+
+    sys.modules['boto3'] = None
+    importlib.reload(loaders)
+
+    yield
+
+    sys.modules.pop('boto3')
+    importlib.reload(loaders)
+
+
+def test_parameter_store_boto_not_available(missing_boto):
+    with pytest.raises(RuntimeError):
+        AwsParameterStore()
 
 
 @mock.patch("prettyconf.loaders.boto3")


### PR DESCRIPTION
Pull request https://github.com/osantana/prettyconf/pull/26 created the `AwsParameterStore` loader, which in turn created a dependency on the `boto3` package.

@hernantz suggested that `prettyconf` should be kept small, and @osantana followed suggesting an optional dependency on `boto3` using the `extras_require` feature from `setuptools`.

This PR creates the optional dependency, represented by the `aws` tag. It is installed with:

```
pip install prettyconf[aws]
```
Attempting to instantiante the `AwsParameterLoader` without previously installing the optional dependency results in a `RuntimeError` exception being raised.