### PR TITLE
Add endpoint_url argument to AwsParameterStore

### DIFF
--- a/prettyconf/loaders.py
+++ b/prettyconf/loaders.py
@@ -310,7 +310,7 @@ class RecursiveSearch(AbstractConfigurationLoader):
 
 
 class AwsParameterStore(AbstractConfigurationLoader):
-    def __init__(self, path="/", aws_access_key_id=None, aws_secret_access_key=None, region_name="us-east-1"):
+    def __init__(self, path="/", aws_access_key_id=None, aws_secret_access_key=None, region_name="us-east-1", endpoint_url=None):
         if not boto3:
             raise RuntimeError(
                 'AwsParameterStore requires [aws] feature. Please install it: "pip install prettyconf[aws]"'
@@ -320,6 +320,7 @@ class AwsParameterStore(AbstractConfigurationLoader):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.region_name = region_name
+        self.endpoint_url = endpoint_url
         self._fetched = False
         self._parameters = {}
 
@@ -336,6 +337,7 @@ class AwsParameterStore(AbstractConfigurationLoader):
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             region_name=self.region_name,
+            endpoint_url=self.endpoint_url,
         )
 
         response = client.get_parameters_by_path(Path=self.path)


### PR DESCRIPTION
The `endpoint_url` argument passed to `AwsParameterStore` initializer is used when instantiating the `ssm` client using `boto3` library.
`boto3` builds endpoint URLs to AWS services automatically when the user does not provide them. However, sometimes we need to specify a custom endpoint URL, for instance, when using a test double like [localstack](https://github.com/localstack/localstack).