### PR TITLE
Added an oop friendly repr

### DIFF
--- a/prettyconf/configuration.py
+++ b/prettyconf/configuration.py
@@ -38,7 +38,7 @@ class Configuration(object):
 
     def __repr__(self):
         loaders = ', '.join([repr(l) for l in self.loaders])
-        return 'Configuration(loaders=[{}])'.format(loaders)
+        return f'{self.__class__.__name__}(loaders=[{loaders}])'
 
     def __call__(self, item, cast=lambda v: v, **kwargs):
         if not callable(cast):

--- a/prettyconf/configuration.py
+++ b/prettyconf/configuration.py
@@ -38,7 +38,7 @@ class Configuration(object):
 
     def __repr__(self):
         loaders = ', '.join([repr(l) for l in self.loaders])
-        return f'{self.__class__.__name__}(loaders=[{loaders}])'
+        return '{}(loaders=[{}])'.format(self.__class__.__name__, loaders)
 
     def __call__(self, item, cast=lambda v: v, **kwargs):
         if not callable(cast):


### PR DESCRIPTION
Allows to use a more specific `__repr__`:
```python
>>> from prettyconf import Configuration
>>> Configuration()
Configuration(loaders=[Environment(var_format=<method 'upper' of 'str' objects>), RecursiveSearch(starting_path=/)])
>>> class Conf(Configuration):
...     pass
... 
>>> Conf()
Conf(loaders=[Environment(var_format=<method 'upper' of 'str' objects>), RecursiveSearch(starting_path=/)])
>>> 
```