### PR TITLE
Provide a sensible default cast based on the default type

### DIFF
--- a/prettyconf/configuration.py
+++ b/prettyconf/configuration.py
@@ -49,7 +49,7 @@ class Configuration(object):
         # Look for a sensible default cast if one is not provided
         if callable(cast):
             cast = cast
-        elif callable(default) or default is NOT_SET:
+        elif callable(default) or default is NOT_SET or default is None:
             cast = identity
         elif isinstance(default, bool):
             cast = self.boolean


### PR DESCRIPTION
- If the user provides a cast function, we use that one, no questions asked.
- if the user sets a default that is an int, str, boolean, float, etc, and doesn't set a cast function, we can set a default one: int(), str(), boolean(), float(), respectively. 
- If the user doesn't set a default value we use the identity cast.
- If the user sets a non callable value as cast, we raise an exception.

Also allowed default to be a callable too.

Will submit the tests and docs soon.