### PR TITLE
Make code block visable

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -17,4 +17,5 @@ The ``AwsParameterStore`` configuration loader depends on the ``boto3`` package.
 If you need to use it, install ``prettyconf`` with the optional feature ``aws``:
 
 .. code-block:: sh
+
     pip install prettyconf[aws]


### PR DESCRIPTION
The code block wasn't visible due to a missing enter around the codeblock.

Current layout on https://prettyconf.readthedocs.io/en/latest/installation.html: 

![image](https://user-images.githubusercontent.com/7871661/91838570-03963000-ec4e-11ea-96d5-5cf5581388c7.png)

