### PR TITLE
update usage docs to match code

### DIFF
--- a/docs/source/loaders.rst
+++ b/docs/source/loaders.rst
@@ -53,7 +53,7 @@ doesn't exist, this loader will be skipped without raising any errors.
     from prettyconf.loaders import EnvFile
 
 
-    config.loaders = [EnvFile(file='.env', required=True, var_format=str.upper)]
+    config.loaders = [EnvFile(filename='.env', var_format=str.upper)]
     config('debug')  # will look for a `DEBUG` variable
 
 


### PR DESCRIPTION
Looks like the docs have gone out of sync with the code:

https://github.com/osantana/prettyconf/blob/92ffacd4024e166b1f0912058dbaddc792cf380c/prettyconf/loaders.py#L171-L178